### PR TITLE
graphviz: On OS X, get the 'expat' dependency from conda, not the system.

### DIFF
--- a/recipes/graphviz-cli/build.sh
+++ b/recipes/graphviz-cli/build.sh
@@ -27,6 +27,13 @@ make
 # This is failing for rtest.
 # Doesn't do anything for the rest
 # make check
+
+if [[ $(uname) == Darwin ]]; then
+    # For some reason, libexpat.1.dylib can't be found without setting the RPATH,
+    # and it even prevents 'make install' from working.
+    install_name_tool -add_rpath ${PREFIX}/lib cmd/dot/.libs/dot
+fi
+
 make install
 
 dot -c

--- a/recipes/graphviz-cli/meta.yaml
+++ b/recipes/graphviz-cli/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - cairo  # [linux]
-    - expat  # [linux]
+    - expat  # [unix]
     - libpng  1.6*  # [unix]
     - libtiff  4.0.*  # [unix]
     - libtool  # [linux]
@@ -37,7 +37,7 @@ requirements:
     - zlib  1.2.*  # [unix]
   run:
     - cairo  # [linux]
-    - expat  # [linux]
+    - expat  # [unix]
     - libpng  1.6*  # [unix]
     - libtiff  4.0.*  # [unix]
     - libtool  # [linux]


### PR DESCRIPTION
The motivation for this PR is explained in this comment:
https://github.com/conda-forge/staged-recipes/pull/568#discussion_r65730358

...which I've also pasted below.

---

> The linker was complaining that it was unable to find the expat dynamic library.

I believe the error you're referring to is this one, which occurs during `make install`:

```
Making install in dot
 ../../config/install-sh -c -d '/miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin'
  /bin/sh ../../libtool   --mode=install /usr/bin/install -c dot dot_builtins '/miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin'
libtool: install: /usr/bin/install -c .libs/dot /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot
libtool: install: /usr/bin/install -c .libs/dot_builtins /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot_builtins
/Applications/Xcode.app/Contents/Developer/usr/bin/make  install-exec-hook
(cd /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin; if test -x dot; then for i in neato twopi fdp circo osage patchwork sfdp; do rm -f $i; ln -s dot $i; done; fi;)
if test "x" = "x"; then if test -x /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot; then if test -x /sbin/ldconfig; then /sbin/ldconfig 2>/dev/null; fi; /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot -c; else /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot_static -c; fi; fi
dyld: Library not loaded: @rpath/libexpat.1.dylib
  Referenced from: /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot
  Reason: Incompatible library version: dot requires version 8.0.0 or later, but libexpat.1.dylib provides version 7.0.0
/bin/sh: line 1: 94089 Trace/BPT trap: 5       /miniconda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/bin/dot -c
```

> I really don't know why, but since Homebrew doesn't require it, I just removed it from OS X.

I think Homebrew doesn't require it because it is apparently already installed on OS X in a system location: `/usr/lib/libexpat.1.dylib`.  Well, that's where it lives if you have the XCode command-line tools installed.  If you don't have the XCode command-line tools, I'm not sure where it lives (if it's present at all).

If we would prefer to use conda for `expat` instead of the system, we can fix the above-mentioned error with an extra command after `make`, but before `make install`.  If you think that change is worth making, I've submitted a PR-onto-this-PR:

https://github.com/ccordoba12/staged-recipes/pull/2

If you don't think it's worth it, then just ignore that PR :-)
